### PR TITLE
:bug: Fixed SEO, added canonical tag in head

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -338,8 +338,11 @@ fn generate_tag_pages(
             }
         };
 
+        let tag_canonical_url = format!("https://dnfolio.me/tags/{tag_slug}.html");
+
         let tag_html_output = base::layout(
             &format!("タグ: {tag_name}"),
+            &tag_canonical_url,
             None,
             None,
             articles_list_markup.clone(),
@@ -620,6 +623,8 @@ pub async fn run() -> Result<()> {
 
             let ogp_image_path = ogp_png_url_path;
 
+            let canonical_url = format!("https://dnfolio.me{}", article.relative_url.to_string_lossy());
+
             let main_content_markup = html! {
                 @if let Some(meta) = &article.metadata {
                     img src=(ogp_image_path) alt=(meta.title);
@@ -654,6 +659,7 @@ pub async fn run() -> Result<()> {
 
             let full_article_html = base::layout(
                 page_title,
+                &canonical_url,
                 article.metadata.as_ref(),
                 Some(&ogp_image_path),
                 articles_list_markup.clone(),
@@ -701,8 +707,11 @@ pub async fn run() -> Result<()> {
 
     let index_ogp_path = ogp::generate_ogp_svg("dnfolio", &ogp_dir)?;
 
+    let index_canonical_url: &str = "https://dnfolio.me/";
+
     let index_html_output = base::layout(
         "dnfolio",
+        index_canonical_url,
         None,
         Some(&index_ogp_path),
         articles_list_markup.clone(),
@@ -730,8 +739,14 @@ pub async fn run() -> Result<()> {
             }
         };
 
+        let privacy_canonical_url = format!(
+            "https://dnfolio.me{}",
+            privacy_page.relative_url.to_string_lossy()
+        );
+
         let privacy_html_output = base::layout(
             "プライバシーポリシー",
+            &privacy_canonical_url,
             None,
             None,
             articles_list_markup.clone(),

--- a/src/templates/base.rs
+++ b/src/templates/base.rs
@@ -3,6 +3,7 @@ use maud::{DOCTYPE, Markup, PreEscaped, html};
 
 pub fn layout(
     page_title: &str,
+    canonical_url: &str,
     metadata: Option<&MetaData>,
     ogp_image_path: Option<&str>,
     sidebar_left_markup: Markup,
@@ -301,6 +302,7 @@ pub fn layout(
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (page_title) }
+                link rel="canonical" href=(canonical_url);
                 meta name="description" content=(description);
                 meta name="keywords" content=(keywords);
                 meta name="author" content="Daiki Nakashima";


### PR DESCRIPTION
SEOが悪くて検索にヒットしなかった。
#70 で `canonical` タグを追加した。
Google Search Consoleで調査すると「重複しています。ユーザーにより、正規ページとして選択されていません」が大量に発生していたのでこれで解決出来たら嬉しい。