### PR TITLE
:bug: Fixed font family in ogp template file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "dnfolio"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnfolio"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2024"
 
 [dependencies]

--- a/src/ogp_template.svg
+++ b/src/ogp_template.svg
@@ -38,7 +38,7 @@
           fill="rgba(26, 26, 26, 0.05)"
           rx="4" ry="4"/>
     <text x="1070" y="585" text-anchor="middle"
-        font-family="sans-serif"
+        font-family="Noto Sans JP"
         font-size="18px" font-weight="600" fill="#495057"
         letter-spacing="1px">
         dnfolio


### PR DESCRIPTION
フォントファミリーを `Noto Sans JP` に変更してビルドしたらPNGファイルでも文字を表示出来た。